### PR TITLE
Fixed shells list not showing up for macOS

### DIFF
--- a/src/main/helpers.ts
+++ b/src/main/helpers.ts
@@ -22,7 +22,7 @@ async function getAvailableShellsForUnix() {
   try {
     const { stdout } = await new Promise<{ stdout: string; stderr: string }>(
       (resolve, reject) => {
-        exec("chsh -l", (error, stdout, stderr) => {
+        exec("cat /etc/shells", (error, stdout, stderr) => {
           if (error) {
             reject(error);
             return;
@@ -35,6 +35,7 @@ async function getAvailableShellsForUnix() {
     return stdout
       .split("\n")
       .filter(Boolean)
+      .filter((line) => !line.startsWith("#"))
       .map((line) => line.trim());
   } catch (error) {
     console.error("Failed to get available shells:", error);

--- a/src/main/helpers.ts
+++ b/src/main/helpers.ts
@@ -35,7 +35,7 @@ async function getAvailableShellsForUnix() {
     return stdout
       .split("\n")
       .filter(Boolean)
-      .filter((line) => !line.startsWith("#"))
+      .filter((line) => !line.trim().startsWith("#"))
       .map((line) => line.trim());
   } catch (error) {
     console.error("Failed to get available shells:", error);


### PR DESCRIPTION
Fixed issue where unix-based OSs do not have access to the `chsh -l` command. Using `cat /etc/shells` does the job, and the output of that command typically looks like this:

```
# List of acceptable shells for chpass(1).
# Ftpd will not allow users to connect who are not using
# one of these shells.

/bin/bash
/bin/csh
/bin/dash
/bin/ksh
/bin/sh
/bin/tcsh
/bin/zsh
```