### PR TITLE
Feat/ctrl t in terminal, auto focus terminal on tab change

### DIFF
--- a/src/renderer/components/TerminalWindow/TerminalView.tsx
+++ b/src/renderer/components/TerminalWindow/TerminalView.tsx
@@ -1,5 +1,5 @@
 import { useTerminalTabs } from "@/context/TerminalTabsProvider";
-import { cn } from "@/lib/utils";
+import { cn, isNewTabKey } from "@/lib/utils";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Terminal } from "@xterm/xterm";
@@ -38,12 +38,20 @@ export default function TerminalView({ visible, sessionId, terminal }: TerminalV
       terminal.write(newData);
     })
 
+    terminal.attachCustomKeyEventHandler((event) => {
+      if (isNewTabKey(event)) {
+        return false;
+      }
+      return true;
+    });
+
     window.terminal.onSessionTerminated(sessionId, (code) => {
       toast.info(`Terminal session ended with code ${code}`);
       closeTab(sessionId);
     });
 
     const handleResize = () => {
+      if (!visible) return;
       fitAddon.fit(); // todo? could debounce this
       const { rows, cols } = fitAddon.proposeDimensions();
       window.terminal.resizeTerminal(sessionId, cols, rows);
@@ -53,7 +61,6 @@ export default function TerminalView({ visible, sessionId, terminal }: TerminalV
 
     setTimeout(() => {
       handleResize();
-      terminal.focus();
     }, 50); // Wait for the terminal to be mounted
 
     return () => {
@@ -61,6 +68,12 @@ export default function TerminalView({ visible, sessionId, terminal }: TerminalV
       window.removeEventListener('resize', handleResize);
     };
   }, []);
+
+  useEffect(() => {
+    if (visible) {
+      terminal.focus();
+    }
+  }, [visible])
 
   return (
     <div className={cn("p-4 h-full w-full bg-background", !visible && "hidden")}>

--- a/src/renderer/context/TerminalTabsProvider/TerminalTabsProvider.tsx
+++ b/src/renderer/context/TerminalTabsProvider/TerminalTabsProvider.tsx
@@ -3,6 +3,7 @@ import { createContext, ReactNode, useContext, useEffect, useState } from "react
 import HostSelectionDialog from "./HostSelectionDialog";
 import { TerminalService } from "@/service/TerminalService/TerminalService";
 import { useConfig } from "../ConfigProvider";
+import { isNewTabKey } from "@/lib/utils";
 
 export type TerminalSession = {
   id: string;
@@ -97,9 +98,4 @@ export function useTerminalTabs() {
     console.warn("useTerminalTabs must be used within a TerminalTabsProvider");
   }
   return context;
-}
-
-function isNewTabKey(e: KeyboardEvent) {
-  // Can also check for ctrl/cmd K
-  return e.key === "t" && (e.metaKey || e.ctrlKey);
 }

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -49,3 +49,7 @@ export function formatShellName(shellPath: string): string {
 
   return friendlyName;
 }
+export function isNewTabKey(e: KeyboardEvent) {
+  // Can also check for ctrl/cmd K
+  return e.key === "t" && (e.metaKey || e.ctrlKey);
+}


### PR DESCRIPTION
Ctrl T allows you to open a new tab, but it was not possible while in terminal as the shortcut was being processed by xtermjs. This PR fixes this.

Also, clicking on a terminal tab will autofocus the terminal.