### PR TITLE
Docker compose file for SSH testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+# This Docker Compose file sets up two SSH servers using the linuxserver/openssh-server image.
+# use `docker-compose up -d` to start the services in detached mode.
+# use `ssh -p 2222 testuser@localhost` to connect to the first SSH server.
+# use `ssh -p 2223 testuser@localhost` to connect to the second SSH server.
+
+version: '3.8'
+
+services:
+  sshd1:
+    image: linuxserver/openssh-server:latest
+    container_name: sshd1
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+      - PASSWORD_ACCESS=true
+      - USER_NAME=testuser
+      - USER_PASSWORD=testpass
+    ports:
+      - '2222:2222'
+    restart: unless-stopped
+
+  sshd2:
+    image: linuxserver/openssh-server:latest
+    container_name: sshd2
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+      - PASSWORD_ACCESS=true
+      - USER_NAME=testuser
+      - USER_PASSWORD=testpass
+    ports:
+      - '2223:2222'
+    restart: unless-stopped


### PR DESCRIPTION
This docker compose creates password-only SSH server, and are for testing purposes.